### PR TITLE
Update upgrading.xml

### DIFF
--- a/en/content/installation/upgrading.xml
+++ b/en/content/installation/upgrading.xml
@@ -102,7 +102,6 @@ shell> mv otrs-x.x.x otrs
                 <para>
                     <itemizedlist>
                         <listitem><para><filename>Kernel/Config.pm</filename></para></listitem>
-                        <listitem><para><filename>Kernel/Config/GenericAgent.pm</filename></para></listitem>
                         <listitem><para><filename>Kernel/Config/Files/ZZZAuto.pm</filename></para></listitem>
                     </itemizedlist>
                 </para>
@@ -121,7 +120,8 @@ shell> mv otrs-x.x.x otrs
                 <title>Restore article data</title>
 
                 <para>
-                    If you configured OTRS to store article data in the filesystem you have to restore the <filename>article</filename> folder to <filename>/opt/otrs/var/</filename>.
+                    If you configured OTRS to store article data in the filesystem you have to restore the <filename>article</filename> folder to <filename>/opt/otrs/var/</filename>
+                    or the folder specified in the SysConfig.
                 </para>
             </section>
 


### PR DESCRIPTION
Remove restore of GenericAgent config file as is it not being used any more in OTRS 5
and add reference to have article path being defined in SysConfig when ArticleStorageFS is selected in the "Restore article data" section.