### PR TITLE
Remove GenericAgent.pm instructions from "Installation From Source"

### DIFF
--- a/de/content/installation/source.xml
+++ b/de/content/installation/source.xml
@@ -123,7 +123,6 @@ $OTRS_HOME/Kernel/Config/*.dist. You must activate them by copying them
 without the ".dist" filename extension.  <screen><![CDATA[
 shell> cd /opt/otrs/
 shell> cp Kernel/Config.pm.dist Kernel/Config.pm
-shell> cp Kernel/Config/GenericAgent.pm.dist Kernel/Config/GenericAgent.pm
     ]]></screen>
 
         </para>

--- a/en/content/installation/source.xml
+++ b/en/content/installation/source.xml
@@ -156,7 +156,6 @@ shell> usermod -G www otrs
     <screen><![CDATA[
 shell> cd /opt/otrs/
 shell> cp Kernel/Config.pm.dist Kernel/Config.pm
-shell> cp Kernel/Config/GenericAgent.pm.dist Kernel/Config/GenericAgent.pm
     ]]></screen>
 
         </para>

--- a/ja/content/installation/source.xml
+++ b/ja/content/installation/source.xml
@@ -122,7 +122,6 @@ $OTRS_HOME/Kernel/Config/*.dist. You must activate them by copying them
 without the ".dist" filename extension.  <screen><![CDATA[
 shell> cd /opt/otrs/
 shell> cp Kernel/Config.pm.dist Kernel/Config.pm
-shell> cp Kernel/Config/GenericAgent.pm.dist Kernel/Config/GenericAgent.pm
     ]]></screen>
 
         </para>

--- a/ru/content/installation/source.xml
+++ b/ru/content/installation/source.xml
@@ -127,7 +127,6 @@ $OTRS_HOME/Kernel/*.dist и $OTRS_HOME/Kernel/Config/*.dist. Скопируйт�
 без расширения ".dist". <screen><![CDATA[
 shell> cd /opt/otrs/
 shell> cp Kernel/Config.pm.dist Kernel/Config.pm
-shell> cp Kernel/Config/GenericAgent.pm.dist Kernel/Config/GenericAgent.pm
     ]]></screen>
 
         </para>

--- a/sw/content/installation/source.xml
+++ b/sw/content/installation/source.xml
@@ -123,7 +123,6 @@ $OTRS_HOME/Kernel/Config/*.dist. You must activate them by copying them
 without the ".dist" filename extension.  <screen><![CDATA[
 shell> cd /opt/otrs/
 shell> cp Kernel/Config.pm.dist Kernel/Config.pm
-shell> cp Kernel/Config/GenericAgent.pm.dist Kernel/Config/GenericAgent.pm
     ]]></screen>
 
         </para>


### PR DESCRIPTION
According to the upgrade notes (4 to 5), the GenericAgent.pm(.dist) is not
needed anymore. However, the "Installation From Source" section still refers
to this file.

> Step 4: Activate Default Config Files
> shell> cp Kernel/Config/GenericAgent.pm.dist Kernel/Config/GenericAgent.pm

Remove this line from the documentation.